### PR TITLE
Remove a skip mark from a test

### DIFF
--- a/affordable_leggins/send_notification.py
+++ b/affordable_leggins/send_notification.py
@@ -18,8 +18,10 @@ def send_email(email, subject, message_body):
         print(response.status_code)
         print(response.body)
         print(response.headers)
+        return True
     except Exception as e:
         print(e.message)
+        return False
 
 
 def email_address():

--- a/tests/test_send_notification.py
+++ b/tests/test_send_notification.py
@@ -2,6 +2,7 @@ import os
 import inspect
 import textwrap
 import pytest
+import mock
 from affordable_leggins.send_notification import (
     send_email,
     email_address,
@@ -11,8 +12,8 @@ from affordable_leggins.send_notification import (
 from fixtures import leggin_with_size_s, leggin_with_size_m
 
 
-@pytest.mark.skip()
-def test_send_email():
+@mock.patch("affordable_leggins.send_notification.SendGridAPIClient")
+def test_send_email(mocked_sendgrid_client):
     email = "kasia@gmail.com"
     subject = "We have found a promotion for you."
     message = "message"


### PR DESCRIPTION
The test, which checks if email with notification is sent once a list of
leggins is downloaded, should not send a real message. To avoid that a
skip mark was using. Now it has been replaced with MagicMock.